### PR TITLE
Remove pdf output from _output.yml

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -25,12 +25,3 @@ bookdown::gitbook:
       instapaper: no
       vk: no
     info: yes
-
-bookdown::pdf_book:
-  includes:
-    in_header: preamble.tex
-  latex_engine: xelatex
-  citation_package: natbib
-  keep_tex: yes
-bookdown::epub_book:
-  stylesheet: style.css


### PR DESCRIPTION
It is unlikely that the book needs to be rendered in PDF in the future, so this code chunk is unnecessary.

This also solves issue #10.